### PR TITLE
Check if data string is empty before retrieving key from storage

### DIFF
--- a/src/MetaContainer.php
+++ b/src/MetaContainer.php
@@ -60,7 +60,7 @@ class MetaContainer implements Contracts\Container {
                 $this->add($key, $data);
             }
             return;
-        } elseif ( ! $data) {
+        } elseif ( ! $data && $data !== '') {
             $this->add($this->store->find($key));
             return;
         }


### PR DESCRIPTION
This fixes an issue where if an empty value is part of a meta item, and it's group or itself is added to the container, it tries to find a meta group with the key of the meta item and usually fails.