### PR TITLE
Proposal to add core:key to the meta output

### DIFF
--- a/src/Eloquent/Meta.php
+++ b/src/Eloquent/Meta.php
@@ -57,6 +57,7 @@ class Meta extends Eloquent implements Group
     {
         $items = $this->items->toArray();
         $refined = [];
+        $refined['core:key'] = $this->id;
 
         foreach ($items as $item) {
             // Check if the item data is in JSON format. If so, we store it as


### PR DESCRIPTION
Hi! Any objections to adding "core:key" meta value to the meta output? so it will render:
<meta name="core:key" content="1263">

Just thought it would be useful so we can see what meta row a page is using.