### PR TITLE
Feature to allow setting a different database connection for metas

### DIFF
--- a/config/meta.php
+++ b/config/meta.php
@@ -4,6 +4,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Meta Database Connection
+    |--------------------------------------------------------------------------
+    |
+    | Set the database connection to use with Coreplex Meta. Full connections
+    | details must be defined in the config/database.php file. If left blank
+    | no connection will be specified in the meta models.
+    |
+    */
+
+    'connection' => env('COREPLEX_META_DATABASE', false),
+
+    /*
+    |--------------------------------------------------------------------------
     | Meta Elements
     |--------------------------------------------------------------------------
     |

--- a/src/Eloquent/Meta.php
+++ b/src/Eloquent/Meta.php
@@ -3,10 +3,28 @@
 namespace Coreplex\Meta\Eloquent;
 
 use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Support\Facades\Config;
 use Coreplex\Meta\Contracts\Group;
 
 class Meta extends Eloquent implements Group
 {
+
+    /**
+     * Create a new Eloquent model instance.
+     *
+     * @param  array  $attributes
+     * @return void
+     */
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct($attributes);
+
+        // If the connection config has been set then use that for the model connection
+        if ($coreplexConnection = Config::get('meta.connection', false)) {
+            $this->connection = $coreplexConnection;
+        }
+    }
+
     /**
      * The fillable fields
      *

--- a/src/Eloquent/Meta/Item.php
+++ b/src/Eloquent/Meta/Item.php
@@ -3,9 +3,27 @@
 namespace Coreplex\Meta\Eloquent\Meta;
 
 use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Support\Facades\Config;
 
 class Item extends Eloquent
 {
+
+    /**
+     * Create a new Eloquent model instance.
+     *
+     * @param  array  $attributes
+     * @return void
+     */
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct($attributes);
+
+        // If the connection config has been set then use that for the model connection
+        if ($coreplexConnection = Config::get('meta.connection', false)) {
+            $this->connection = $coreplexConnection;
+        }
+    }
+
     /**
      * Define the database table used for the model
      *


### PR DESCRIPTION
In newer versions of Laravel if the relation model is on a different connection, Laravel will now inherit that connection for the meta models.

Whereas before it would use the default connection.

If the meta database connection needs to be different from the main connection this merge will now allow it.