### PR TITLE
Updates Managers\Store to use  property of Illuminate\Support\Manager…

### DIFF
--- a/src/Managers/Store.php
+++ b/src/Managers/Store.php
@@ -19,7 +19,9 @@ class Store extends Manager
      */
     public function getDefaultDriver()
     {
-        return $this->container['config']['drivers.store'];
+        $container = ! empty($this->container) ? $this->container : $this->app;
+
+        return $container['config']['drivers.store'];
     }
 
     /**
@@ -30,6 +32,8 @@ class Store extends Manager
      */
     public function setDefaultDriver($name)
     {
-        $this->container['config']['drivers.store'] = $name;
+        $container = ! empty($this->container) ? $this->container : $this->app;
+
+        $container['config']['drivers.store'] = $name;
     }
 }

--- a/src/Managers/Store.php
+++ b/src/Managers/Store.php
@@ -19,7 +19,7 @@ class Store extends Manager
      */
     public function getDefaultDriver()
     {
-        return $this->app['config']['drivers.store'];
+        return $this->container['config']['drivers.store'];
     }
 
     /**
@@ -30,6 +30,6 @@ class Store extends Manager
      */
     public function setDefaultDriver($name)
     {
-        $this->app['config']['drivers.store'] = $name;
+        $this->container['config']['drivers.store'] = $name;
     }
 }


### PR DESCRIPTION
Allows Laravel 8 compatibility by updating `Managers\Store` to use `$container` property of `Illuminate\Support\Manager`. `$app` property has been removed in Laravel 8.